### PR TITLE
chore: bump ev-node and ignite app

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       EVNODE_VERSION: "v1.0.0-beta.2.0.20250905131737-cacd3c987245"
       IGNITE_VERSION: "v29.3.1"
-      IGNITE_EVOLVE_APP_VERSION: "0f9a286e616364f7795f97981b76c79c5512b759" # use tagged when apps has tagged (blocked on things)
+      v1.0.0-beta.2.0.20250908090838-0584153217ed: "main" # use tagged when apps has tagged (blocked on things)
       EVOLVE_IMAGE_REPO: "evolve-gm"
       EVOLVE_IMAGE_TAG: "latest"
 
@@ -41,7 +41,7 @@ jobs:
           docker build \
             --build-arg EVNODE_VERSION=${{ env.EVNODE_VERSION }} \
             --build-arg IGNITE_VERSION=${{ env.IGNITE_VERSION }} \
-            --build-arg IGNITE_EVOLVE_APP_VERSION=${{ env.IGNITE_EVOLVE_APP_VERSION }} \
+            --build-arg v1.0.0-beta.2.0.20250908090838-0584153217ed=${{ env.v1.0.0-beta.2.0.20250908090838-0584153217ed }} \
             -t ${{ env.EVOLVE_IMAGE_REPO }}:${{ env.EVOLVE_IMAGE_TAG }} \
             .
 
@@ -61,7 +61,7 @@ jobs:
       DO_NOT_TRACK: true
       EVNODE_VERSION: "v1.0.0-beta.2.0.20250905131737-cacd3c987245"
       IGNITE_VERSION: "v29.3.1"
-      IGNITE_EVOLVE_APP_VERSION: "0f9a286e616364f7795f97981b76c79c5512b759" # use tagged when apps has tagged (blocked on things)
+      v1.0.0-beta.2.0.20250908090838-0584153217ed: "main" # use tagged when apps has tagged (blocked on things)
     outputs:
       carol_mnemonic: ${{ steps.save_mnemonic.outputs.carol_mnemonic }}
       gmd_home: ${{ steps.paths.outputs.GMD_HOME }}
@@ -88,7 +88,7 @@ jobs:
           cd gm
 
           # install evolve app
-          ignite app install github.com/ignite/apps/evolve@$IGNITE_EVOLVE_APP_VERSION
+          ignite app install github.com/ignite/apps/evolve@$v1.0.0-beta.2.0.20250908090838-0584153217ed
 
           # add evolve to the chain
           ignite evolve add

--- a/.github/workflows/migration_test.yml
+++ b/.github/workflows/migration_test.yml
@@ -15,7 +15,7 @@ jobs:
       DO_NOT_TRACK: true
       EVNODE_VERSION: "v1.0.0-beta.2.0.20250905131737-cacd3c987245"
       IGNITE_VERSION: "v29.3.1"
-      IGNITE_EVOLVE_APP_VERSION: "0f9a286e616364f7795f97981b76c79c5512b759" # use tagged when apps has tagged (blocked on things)
+      v1.0.0-beta.2.0.20250908090838-0584153217ed: "main" # use tagged when apps has tagged (blocked on things)
     steps:
       - uses: actions/checkout@v5
         with:
@@ -173,7 +173,7 @@ jobs:
           GO_EXECUTION_ABCI_DIR=$CURRENT_DIR
 
           # install evolve app
-          ignite app install github.com/ignite/apps/evolve@$IGNITE_EVOLVE_APP_VERSION
+          ignite app install github.com/ignite/apps/evolve@$v1.0.0-beta.2.0.20250908090838-0584153217ed
 
           # add evolve to the chain + wire optional modules
           ignite evolve add --migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 # Set environment variables
 ENV EVNODE_VERSION=v1.0.0-beta.2.0.20250905131737-cacd3c987245
 ENV IGNITE_VERSION=v29.3.1
-ENV IGNITE_EVOLVE_APP_VERSION=main
+ENV v1.0.0-beta.2.0.20250908090838-0584153217ed=main
 
 RUN curl -sSL https://get.ignite.com/cli@${IGNITE_VERSION}! | bash
 
@@ -21,7 +21,7 @@ RUN ignite scaffold chain gm --no-module --skip-git --address-prefix gm
 
 WORKDIR /workspace/gm
 
-RUN ignite app install github.com/ignite/apps/evolve@${IGNITE_EVOLVE_APP_VERSION} && \
+RUN ignite app install github.com/ignite/apps/evolve@${v1.0.0-beta.2.0.20250908090838-0584153217ed} && \
     ignite evolve add
 
 RUN go mod edit -replace github.com/evstack/ev-node=github.com/evstack/ev-node@${EVNODE_VERSION} && \


### PR DESCRIPTION
Updated ignite app PR has been merged. Meaning we can use main again.
All tests but migrations should now pass.

ref: https://github.com/evstack/ev-abci/pull/236#issuecomment-3266933620