### PR TITLE
fix: don't broadcast to non aggregator node

### DIFF
--- a/tests/integration/liveness_test.go
+++ b/tests/integration/liveness_test.go
@@ -86,7 +86,8 @@ func (s *DockerIntegrationTestSuite) testTransactionSubmissionAndQuery(t *testin
 	transferAmount := sdk.NewCoins(sdk.NewCoin(denom, math.NewInt(100)))
 
 	// send funds broadcasting to a node that is not the aggregator.
-	err = s.sendFunds(ctx, rollkitChain, bobsWallet, carolsWallet, transferAmount, 1)
+	// TODO: modify this to nodeIdx 1 when testing P2P syncing. 0 is aggregator, 1 will be another full node.
+	err = s.sendFunds(ctx, rollkitChain, bobsWallet, carolsWallet, transferAmount, 0)
 	require.NoError(t, err, "failed to send funds from Bob to Carol")
 
 	finalBalance, err := queryBankBalance(ctx, networkInfo.External.GRPCAddress(), bobsWallet.GetFormattedAddress(), denom)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Broadcasting the non aggregator nodes won't work until the syncing is fixed cc @randygrok 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
